### PR TITLE
fix 'ReferenceError: expressApp is not defined'

### DIFF
--- a/serverless-bolt-template/aws-js/app.js
+++ b/serverless-bolt-template/aws-js/app.js
@@ -124,7 +124,7 @@ app.error((error) => {
 
 // ------------------------------------------------------
 // OAuth flow
-expressApp.get('/slack/installation', (req, res) => {
+module.exports.expressApp.get('/slack/installation', (req, res) => {
   const clientId = process.env.SLACK_CLIENT_ID;
   const scopesCsv = 'commands,users:read,users:read.email,team:read'; // TODO: modify
   const state = 'randomly-generated-string'; // TODO: implement the logic
@@ -132,7 +132,7 @@ expressApp.get('/slack/installation', (req, res) => {
   res.redirect(url);
 });
 
-expressApp.get('/slack/oauth', (req, res) => {
+module.exports.expressApp.get('/slack/oauth', (req, res) => {
   // TODO: make sure if req.query.state is valid
   app.client.oauth.access({
     code: req.query.code,


### PR DESCRIPTION
I was getting the following:

```
Serverless: POST /slack/events (λ: app)
Serverless: Error while loading app
[ 'ReferenceError: expressApp is not defined',
  'at Object.<anonymous> (/Users/msilverberg/Code/serverless-bolt-template-aws-js/app.js:127:1)',
  'at Module._compile (internal/modules/cjs/loader.js:688:30)',
  'at Object.Module._extensions..js (internal/modules/cjs/loader.js:699:10)',
  'at Module.load (internal/modules/cjs/loader.js:598:32)',
  'at tryModuleLoad (internal/modules/cjs/loader.js:537:12)',
  'at Function.Module._load (internal/modules/cjs/loader.js:529:3)',
  'at Module.require (internal/modules/cjs/loader.js:636:17)',
  'at require (internal/modules/cjs/helpers.js:20:18)',
  'at Object.<anonymous> (/Users/msilverberg/Code/serverless-bolt-template-aws-js/handler.js:3:13)',
  'at Module._compile (internal/modules/cjs/loader.js:688:30)',
  'at Object.Module._extensions..js (internal/modules/cjs/loader.js:699:10)',
  'at Module.load (internal/modules/cjs/loader.js:598:32)',
  'at tryModuleLoad (internal/modules/cjs/loader.js:537:12)',
  'at Function.Module._load (internal/modules/cjs/loader.js:529:3)',
  'at Module.require (internal/modules/cjs/loader.js:636:17)',
  'at require (internal/modules/cjs/helpers.js:20:18)',
  'at Object.createHandler (/Users/msilverberg/Code/serverless-bolt-template-aws-js/node_modules/serverless-offline/src/functionHelper.js:192:17)',
  'at handler (/Users/msilverberg/Code/serverless-bolt-template-aws-js/node_modules/serverless-offline/src/index.js:624:40)',
  'at Object.internals.handler (/Users/msilverberg/Code/serverless-bolt-template-aws-js/node_modules/hapi/lib/handler.js:101:51)',
  'at request._protect.run (/Users/msilverberg/Code/serverless-bolt-template-aws-js/node_modules/hapi/lib/handler.js:32:23)',
  'at module.exports.internals.Protect.internals.Protect.run (/Users/msilverberg/Code/serverless-bolt-template-aws-js/node_modules/hapi/lib/protect.js:60:12)',
  'at exports.execute (/Users/msilverberg/Code/serverless-bolt-template-aws-js/node_modules/hapi/lib/handler.js:26:22)',
  'at each (/Users/msilverberg/Code/serverless-bolt-template-aws-js/node_modules/hapi/lib/request.js:401:16)',
  'at iterate (/Users/msilverberg/Code/serverless-bolt-template-aws-js/node_modules/items/lib/index.js:36:13)',
  'at done (/Users/msilverberg/Code/serverless-bolt-template-aws-js/node_modules/items/lib/index.js:28:25)',
  'at internals.Auth.payload (/Users/msilverberg/Code/serverless-bolt-template-aws-js/node_modules/hapi/lib/auth.js:235:16)',
  'at each (/Users/msilverberg/Code/serverless-bolt-template-aws-js/node_modules/hapi/lib/request.js:401:16)',
  'at iterate (/Users/msilverberg/Code/serverless-bolt-template-aws-js/node_modules/items/lib/index.js:36:13)',
  'at done (/Users/msilverberg/Code/serverless-bolt-template-aws-js/node_modules/items/lib/index.js:28:25)',
  'at onParsed (/Users/msilverberg/Code/serverless-bolt-template-aws-js/node_modules/hapi/lib/route.js:341:20)',
  'at Subtext.parse (/Users/msilverberg/Code/serverless-bolt-template-aws-js/node_modules/hapi/lib/route.js:380:20)',
  'at next (/Users/msilverberg/Code/serverless-bolt-template-aws-js/node_modules/subtext/lib/index.js:46:26)',
  'at Wreck.read (/Users/msilverberg/Code/serverless-bolt-template-aws-js/node_modules/subtext/lib/index.js:243:16)',
  'at finish (/Users/msilverberg/Code/serverless-bolt-template-aws-js/node_modules/wreck/lib/index.js:374:20)',
  'at wrapped (/Users/msilverberg/Code/serverless-bolt-template-aws-js/node_modules/wreck/node_modules/hoek/lib/index.js:879:20)',
  'at module.exports.internals.Recorder.onReaderFinish (/Users/msilverberg/Code/serverless-bolt-template-aws-js/node_modules/wreck/lib/index.js:449:16)',
  'at Object.onceWrapper (events.js:273:13)',
  'at module.exports.internals.Recorder.emit (events.js:187:15)',
  'at module.exports.internals.Recorder.EventEmitter.emit (domain.js:460:23)',
  'at finishMaybe (_stream_writable.js:641:14)',
  'at endWritable (_stream_writable.js:649:3)',
  'at module.exports.internals.Recorder.Writable.end (_stream_writable.js:589:5)',
  'at IncomingMessage.onend (_stream_readable.js:628:10)',
  'at Object.onceWrapper (events.js:273:13)',
  'at IncomingMessage.emit (events.js:187:15)',
  'at IncomingMessage.EventEmitter.emit (domain.js:442:20)',
  'at endReadableNT (_stream_readable.js:1094:12)' ]
```